### PR TITLE
fix(Dockerfile): use exec form and -- separator in ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -328,7 +328,9 @@ RUN chown -R $GF_UID:$GF_GID "$GF_PATHS_DATA" "$GF_PATHS_HOME" "$GF_PATHS_LOGS" 
 
 USER "$GF_UID"
 
-ENTRYPOINT /usr/share/CmfEntrypoint/CmfEntrypoint "/bin/sh /run.sh" \
-       --process-secrets \
-       --layer="grafana" \
-       --target-directory="/etc/grafana/provisioning"
+ENTRYPOINT [ "/usr/share/CmfEntrypoint/CmfEntrypoint", \
+      "--process-secrets", \
+      "--layer=grafana", \
+      "--target-directory=/etc/grafana/provisioning" ,\
+      "--" ,\
+      "/run.sh" ]


### PR DESCRIPTION
**What is this feature?**

Updates the `Dockerfile` by changing `ENTRYPOINT` to use exec-form and using `--` as the separator between the `CmfEntrypoint` flags and the actual main process entrypoint.

**Why do we need this feature?**

Changes to the CmfEntrypoint were introduced in 12.0/dev and require all Dockerfiles entrypoints to comply.

**Who is this feature for?**

Backend stuff.

**Which issue(s) does this PR fix?**:
Container not starting up in 12.0/dev.
